### PR TITLE
feat(sf-toolbox): configure the herdr agent skill

### DIFF
--- a/playbooks/roles/sf-toolbox/tasks/herdr.yml
+++ b/playbooks/roles/sf-toolbox/tasks/herdr.yml
@@ -72,3 +72,29 @@
         name: herdr
         state: latest
         path: /home/linuxbrew/.linuxbrew/bin
+
+- name: Configure the herdr agent skill
+  tags: [sf-toolbox, packages, herdr, ai-harness]
+  block:
+    - name: Check if herdr skill setup script exists and is executable
+      become: true
+      become_user: "{{ system.username | default(current_user) }}"
+      ansible.builtin.stat:
+        path: "{{ sparkdock.path | default(sparkdock_default_path) }}/sjust/scripts/herdr/setup.sh"
+      register: herdr_skill_setup_script
+
+    - name: Run herdr skill setup script
+      become: true
+      become_user: "{{ system.username | default(current_user) }}"
+      ansible.builtin.command: "{{ sparkdock.path | default(sparkdock_default_path) }}/sjust/scripts/herdr/setup.sh"
+      when:
+        - herdr_skill_setup_script.stat.exists
+        - herdr_skill_setup_script.stat.executable | default(false)
+      changed_when: true
+
+    - name: Warn user to manually run herdr skill setup
+      ansible.builtin.debug:
+        msg: >-
+          WARNING: Automatic herdr skill installation was not possible.
+          Please run `ajust sf-herdr-skill-install` manually to complete the setup.
+      when: not herdr_skill_setup_script.stat.exists or not (herdr_skill_setup_script.stat.executable | default(false))


### PR DESCRIPTION
### **User description**
> :robot: _This was written by an AI agent on behalf of @paolomainardi._

## Summary

`sf-toolbox` already installs the `herdr` binary. This adds the matching agent skill, so Linux machines get the same thing macOS gets from sparkdock.

herdr prints its own skill on stdout with `herdr --skill`, and sparkdock owns the script that turns that into an installed skill. This task calls that script, the same way the caveman and RTK tasks do.

## What changed

`playbooks/roles/sf-toolbox/tasks/herdr.yml` gains a `Configure the herdr agent skill` block that runs after both install paths (Arch from GitHub releases, Debian from Homebrew):

- **stats** `{{ sparkdock.path | default(sparkdock_default_path) }}/sjust/scripts/herdr/setup.sh`
- **runs** it as `{{ system.username | default(current_user) }}`, so the skill lands in the user's home
- **warns** with the manual `ajust sf-herdr-skill-install` fallback when the script is missing or not executable

Tags are `[sf-toolbox, packages, herdr, ai-harness]`.

## Dependency and merge order

The script arrives with sparkfabrik/sparkdock#588. Until that is merged and machines have pulled it, this task takes the warn-and-continue path, so merging this first is harmless but does nothing. Merge the sparkdock PR first.

## Testing

`ansible-playbook --syntax-check playbooks/sf-toolbox.yml` passes. The script itself was verified in the sparkdock PR, including a repeated run for idempotency and the resulting per-tool symlinks on this Arch host.


___

### **PR Type**
Enhancement


___

### **Description**
- Configure `herdr` AI agent skill automatically

- Run Sparkdock setup script as target user

- Warn with manual fallback when unavailable


___

### Diagram Walkthrough


```mermaid
flowchart LR
  Herdr["Installed herdr binary"]
  Script["Sparkdock herdr setup script"]
  Skill["User AI agent skill"]
  Herdr -- "provides skill output" --> Script
  Script -- "generates and installs" --> Skill
```



<details> <summary><h3> File Walkthrough</h3></summary>

<table><thead><tr><th></th><th align="left">Relevant files</th></tr></thead><tbody><tr><td><strong>Enhancement</strong></td><td><table>
<tr>
  <td>
    <details>
      <summary><strong>herdr.yml</strong><dd><code>Configure herdr agent skill through Sparkdock script</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

playbooks/roles/sf-toolbox/tasks/herdr.yml

<ul><li>Check whether Sparkdock's <code>herdr</code> setup script exists and is executable.<br> <li> Run the script as the configured target user.<br> <li> Emit a manual <code>ajust sf-herdr-skill-install</code> fallback warning when <br>unavailable.<br> <li> Add the <code>ai-harness</code> tag to skill configuration tasks.</ul>


</details>


  </td>
  <td><a href="https://github.com/sparkfabrik/archlinux-ansible-provisioner/pull/244/files#diff-c8533b38b3f6830f333c20376f6102ce9d40a6153e0f2968965544fe41d00b19">+26/-0</a>&nbsp; &nbsp; </td>

</tr>
</table></td></tr></tr></tbody></table>

</details>

___



---

> Assisted-by: pr-agent/gpt-5.6-terra