### PR TITLE
feat(install): recognize Omarchy in OS detection

### DIFF
--- a/README.md
+++ b/README.md
@@ -15,7 +15,7 @@ The official guide is an invaluable resource for understanding the installation 
 
 ## sf-toolbox — SparkFabrik Linux Toolbox
 
-Standalone installer for SparkFabrik shared dev tools on Arch Linux, CachyOS, and Debian/Ubuntu. Works independently from the full system provisioner.
+Standalone installer for SparkFabrik shared dev tools on Arch Linux, CachyOS, Omarchy, and Debian/Ubuntu. Works independently from the full system provisioner.
 
 ### Quick Bootstrap
 
@@ -41,7 +41,7 @@ SKIP_TAGS=gcloud sf-toolbox             # Skip specific tags
 
 ### Requirements
 
-- Arch Linux, CachyOS, Debian, or Ubuntu
+- Arch Linux, CachyOS, Omarchy, Debian, or Ubuntu
 - `git`, `zsh`, `docker`, `curl`, `python3` (and `node`/`npm` on Arch)
 
 ## About This Provisioner

--- a/bin/install.linux
+++ b/bin/install.linux
@@ -2,7 +2,7 @@
 # sf-toolbox — SparkFabrik Linux Toolbox installer and updater
 #
 # Installs/updates SparkFabrik shared dev tooling (sparkdock, AI tools,
-# cloud-native CLIs, http-proxy) on Arch Linux, CachyOS, and Debian/Ubuntu.
+# cloud-native CLIs, http-proxy) on Arch Linux, CachyOS, Omarchy, and Debian/Ubuntu.
 #
 # Usage:
 #   bin/install.linux          # First install or update
@@ -22,7 +22,7 @@ show_help() {
   printf "  %s%ssf-toolbox%s — SparkFabrik Linux Toolbox installer and updater\n" "${BOLD}" "${BLUE}" "${NC}"
   printf "\n"
   printf "  Installs/updates SparkFabrik shared dev tooling (sparkdock, AI tools,\n"
-  printf "  cloud-native CLIs, http-proxy) on Arch Linux, CachyOS, and Debian/Ubuntu.\n"
+  printf "  cloud-native CLIs, http-proxy) on Arch Linux, CachyOS, Omarchy, and Debian/Ubuntu.\n"
   printf "\n"
   printf "  ${BOLD}Detected OS:${NC} ${GREEN}%s %s${NC} (%s)\n" "${os_icon}" "${OS_DISPLAY}" "${OS_FAMILY}"
   printf "\n"
@@ -84,15 +84,23 @@ detect_os() {
   . "${os_release_file}"
 
   case "${ID:-}" in
-    arch|archlinux|cachyos|endeavouros|manjaro)
+    arch|archlinux|cachyos|endeavouros|manjaro|omarchy)
       OS_FAMILY="Archlinux"
       ;;
     ubuntu|debian|pop|linuxmint)
       OS_FAMILY="Debian"
       ;;
     *)
-      log_error "Unsupported OS: ${ID:-unknown}. Only Arch Linux, CachyOS, and Debian/Ubuntu are supported."
-      exit 1
+      # Fall back to ID_LIKE so unlisted derivatives (Arch- or Debian-based)
+      # are still recognized instead of rejected outright.
+      case " ${ID_LIKE:-} " in
+        *" arch "*)   OS_FAMILY="Archlinux" ;;
+        *" debian "*) OS_FAMILY="Debian" ;;
+        *)
+          log_error "Unsupported OS: ${ID:-unknown}. Only Arch Linux (incl. CachyOS, Omarchy) and Debian/Ubuntu are supported."
+          exit 1
+          ;;
+      esac
       ;;
   esac
   OS_DISPLAY="${PRETTY_NAME:-${OS_FAMILY}}"


### PR DESCRIPTION
### **User description**
> :robot: _This was written by an AI agent on behalf of @stefanomainardi._

## Summary

`sf-toolbox` failed on Omarchy at OS detection:

```text
ERROR Unsupported OS: omarchy. Only Arch Linux, CachyOS, and Debian/Ubuntu are supported.
```

Omarchy is Arch-based (`ID=omarchy`, `ID_LIKE=arch`). Only `bin/install.linux` blocked it. The Ansible role and `bin/bootstrap.sh` already handle it.

## Changes

- **`detect_os()` in `bin/install.linux`.** Add `omarchy` to the Archlinux `case` branch.
- **`ID_LIKE` fallback.** When `ID` is unlisted, resolve the family from `ID_LIKE` (`arch` to Archlinux, `debian` to Debian) instead of erroring out. This covers Omarchy a second time and future derivatives.
- **Docs and strings.** List Omarchy in the script header, the `--help` output, the unsupported-OS error, and `README.md`.

## Why the other layers needed no change

- **Ansible** already maps Omarchy to `os_family=Archlinux`, confirmed with `ansible localhost -m setup -a filter=ansible_os_family`. The `os_family == "Archlinux"` task gates work unchanged.
- **`bin/bootstrap.sh`** installs git based on `/etc/arch-release`, which Omarchy ships.

## Verification

Against the real Omarchy `/etc/os-release` (`ID=omarchy`, `ID_LIKE=arch`), `detect_os` resolves `OS_FAMILY=Archlinux`.

Closes #245


___

### **PR Type**
Enhancement


___

### **Description**
- Add Omarchy support to Linux installer detection

- Recognize Arch and Debian derivatives via `ID_LIKE`

- Document Omarchy as a supported distribution


___

### Diagram Walkthrough


```mermaid
flowchart LR
  Release["/etc/os-release metadata"]
  Detect["detect_os()"]
  Family["Supported OS family"]
  Release -- "`ID` or `ID_LIKE`" --> Detect
  Detect -- "resolves" --> Family
```



<details> <summary><h3> File Walkthrough</h3></summary>

<table><thead><tr><th></th><th align="left">Relevant files</th></tr></thead><tbody><tr><td><strong>Documentation</strong></td><td><table>
<tr>
  <td>
    <details>
      <summary><strong>README.md</strong><dd><code>Document Omarchy as a supported Linux distribution</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

README.md

<ul><li>Add Omarchy to the supported distributions overview.<br> <li> Include Omarchy in the installation requirements list.</ul>


</details>


  </td>
  <td><a href="https://github.com/sparkfabrik/archlinux-ansible-provisioner/pull/246/files#diff-b335630551682c19a781afebcf4d07bf978fb1f8ac04c6bf87428ed5106870f5">+2/-2</a>&nbsp; &nbsp; &nbsp; </td>

</tr>
</table></td></tr><tr><td><strong>Enhancement</strong></td><td><table>
<tr>
  <td>
    <details>
      <summary><strong>install.linux</strong><dd><code>Detect Omarchy and supported derivative OS families</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

bin/install.linux

<ul><li>Classify <code>omarchy</code> as part of the <code>Archlinux</code> family.<br> <li> Fall back to <code>ID_LIKE</code> for unlisted Arch- and Debian-based derivatives.<br> <li> Update installer help text and unsupported-OS messaging with Omarchy <br>support.</ul>


</details>


  </td>
  <td><a href="https://github.com/sparkfabrik/archlinux-ansible-provisioner/pull/246/files#diff-877d32c0cf553e367aaf499a3e8982edb759c30fde98862b7039c47a2f128e58">+13/-5</a>&nbsp; &nbsp; </td>

</tr>
</table></td></tr></tr></tbody></table>

</details>

___



---

> Assisted-by: pr-agent/gpt-5.6-terra