### PR TITLE
feat(sf-toolbox): install Upterm

### DIFF
--- a/.github/workflows/test-toolbox.yml
+++ b/.github/workflows/test-toolbox.yml
@@ -48,7 +48,14 @@ jobs:
           opencode version || opencode --version
           copilot --version
           claude --version
+          upterm version
           /opt/google-cloud-sdk/bin/gcloud --version
+
+      - name: Verify Upterm idempotency
+        run: |
+          output=$(TAGS=upterm bin/install.linux)
+          echo "${output}"
+          echo "${output}" | grep -q "changed=0"
 
   toolbox-ubuntu-2604:
     name: Ubuntu 26.04
@@ -82,6 +89,7 @@ jobs:
           opencode version || opencode --version
           copilot --version
           claude --version
+          upterm version
           /opt/google-cloud-sdk/bin/gcloud --version
 
   toolbox-arch:
@@ -115,7 +123,16 @@ jobs:
           just --version
           gum --version
           glab --version
+          upterm version
           /opt/google-cloud-sdk/bin/gcloud --version
+
+      - name: Verify Upterm idempotency
+        env:
+          SUDO_USER: testuser
+        run: |
+          output=$(TAGS=upterm bin/install.linux)
+          echo "${output}"
+          echo "${output}" | grep -q "changed=0"
 
   conflict-detection-arch:
     name: Arch conflict detection
@@ -196,6 +213,7 @@ jobs:
           just --version
           gum --version
           glab --version
+          upterm version
           /opt/google-cloud-sdk/bin/gcloud --version
 
   toolbox-conflict-detection:
@@ -270,4 +288,5 @@ jobs:
           just --version
           gum --version
           glab --version
+          upterm version
           /opt/google-cloud-sdk/bin/gcloud --version

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ## [Unreleased]
 
 ### Added
+
+- Added Upterm to `sf-toolbox`: Arch Linux and Omarchy install pinned checksum-verified upstream release binaries, while Debian/Ubuntu install the upstream Homebrew cask; the shared Sparkdock recipes provide the same workflows through Linux `ajust`
 - Added a `claude-output-style` task that defaults Claude Code's output style to `Concise`. Output styles modify the system prompt, so the guidance is prompt-cached and survives context compaction, unlike a CLAUDE.md entry. The task calls sparkdock's `claude-output-style.py`, which writes the key only when no style is set, so a developer who picks another one keeps it across provisioning runs; `/config` still wins per project and `ajust claude-output-style-reset` removes it. Skipped with a warning when the sparkdock checkout is absent, matching the gh-gate task ([sparkfabrik/sparkdock#600](https://github.com/sparkfabrik/sparkdock/pull/600))
 - The `sf-toolbox` role now installs the SparkFabrik Omarchy theme on Omarchy machines (tag `omarchy-theme`): the theme is cloned the way Omarchy installs extra themes, as a git checkout under `~/.config/omarchy/themes`, so `omarchy theme update` keeps it current, and the theme's screensaver hook is installed into `~/.config/omarchy/hooks/theme-set.d`, which Omarchy does not rewrite. The theme stays available in the theme switcher without being applied: set `sf_toolbox_omarchy_theme_set` to apply it. Override the source with `sf_toolbox_omarchy_theme_repo`, `sf_toolbox_omarchy_theme_name` and `sf_toolbox_omarchy_theme_version`
 - Mission Control now reads the developer's GitLab work: one card per project they actually worked on recently (named after the client for customer groups and after the project itself for internal ones), with open issues, merge requests, review requests and replies, an activity sparkline, the latest issues and merge requests as clickable rows, and quick actions for GitLab, issues, a terminal in the project and its local site. Alongside: recent pipeline history grouped per project (green runs included, most recently active first), the items waiting on the developer grouped per project and split between open and closed, their own open merge requests, and a weekly activity chart. Backed by a single cached `sf-toolbox-status gitlab` call, and reachable with `CTRL + SUPER + ALT + S` (configurable through `sf_toolbox_mission_control_key`)
@@ -90,6 +92,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Removed
 
+- Removed the legacy `tmate` AUR package from full Arch Linux provisioning; `sf-toolbox` also removes existing `tmate` and third-party Upterm packages before installing the upstream binary
 - Removed `playbooks/roles/packages/tasks/ai.yml`, `glab.yml`, `gcloud.yml`, `homebrew.yml` (merged into sf-toolbox)
 - Removed `playbooks/roles/docker/tasks/sparkfabrik-http-proxy.yml` (merged into sf-toolbox)
 - Removed `playbooks/roles/sparkdock/tasks/packages-arch.yml` and `packages-debian.yml` (merged into sf-toolbox)

--- a/README.md
+++ b/README.md
@@ -36,7 +36,7 @@ SKIP_TAGS=gcloud sf-toolbox             # Skip specific tags
 - **AI Coding**: opencode, openspec
 - **Cloud/DevOps**: gcloud, glab, mkcert, docker (must be pre-installed)
 - **Task Runner**: just, ajust (SparkFabrik wrapper)
-- **Utilities**: gum
+- **Utilities**: gum, Upterm
 - **HTTP Proxy**: spark-http-proxy (local .loc domains)
 
 ### Requirements

--- a/bin/install.linux
+++ b/bin/install.linux
@@ -209,6 +209,7 @@ is_sf_managed() {
     ajust) [[ "${path}" == "/usr/local/bin/ajust" ]] && return 0 ;;
     rtk) [[ "${path}" == "/usr/local/bin/rtk" ]] && return 0 ;;
     herdr) [[ "${path}" == "/usr/local/bin/herdr" ]] && return 0 ;;
+    upterm) [[ "${path}" == "/usr/local/bin/upterm" ]] && return 0 ;;
     spark-http-proxy) [[ "${path}" == "/usr/local/bin/spark-http-proxy" ]] && return 0 ;;
     claude) [[ "${path}" == "${HOME}/.local/bin/claude" ]] && return 0 ;;
   esac

--- a/playbooks/roles/packages/tasks/development.yml
+++ b/playbooks/roles/packages/tasks/development.yml
@@ -38,7 +38,6 @@
           - rancher-k3d-bin
           - stern
           - syft
-          - tmate
       become: yes
       become_user: aur_builder
 

--- a/playbooks/roles/sf-toolbox/tasks/homebrew.yml
+++ b/playbooks/roles/sf-toolbox/tasks/homebrew.yml
@@ -1,7 +1,7 @@
 ---
 # ─── Homebrew bootstrap (Debian/Ubuntu only) ───────────────────────────────
 - name: Bootstrap Homebrew on Debian/Ubuntu
-  tags: [sf-toolbox, packages, homebrew]
+  tags: [sf-toolbox, packages, homebrew, upterm]
   when: ansible_facts['os_family'] == "Debian"
   block:
     - name: Check if Homebrew is already installed

--- a/playbooks/roles/sf-toolbox/tasks/main.yml
+++ b/playbooks/roles/sf-toolbox/tasks/main.yml
@@ -29,6 +29,9 @@
 - name: Install herdr
   import_tasks: herdr.yml
 
+- name: Install Upterm
+  import_tasks: upterm.yml
+
 - name: Configure caveman
   import_tasks: caveman.yml
 

--- a/playbooks/roles/sf-toolbox/tasks/upterm.yml
+++ b/playbooks/roles/sf-toolbox/tasks/upterm.yml
@@ -1,0 +1,113 @@
+---
+- name: Install Upterm from upstream releases (Archlinux)
+  tags: [sf-toolbox, packages, upterm]
+  when: ansible_facts['os_family'] == "Archlinux"
+  block:
+    - name: Remove legacy and third-party terminal-sharing packages
+      community.general.pacman:
+        name:
+          - tmate
+          - upterm
+          - upterm-bin
+        state: absent
+
+    - name: Fail on unsupported architecture for Upterm
+      ansible.builtin.fail:
+        msg: "Upterm does not provide a managed binary for architecture: {{ ansible_facts['architecture'] }}"
+      when: ansible_facts['architecture'] not in toolbox.upterm.architectures
+
+    - name: Set Upterm release facts
+      ansible.builtin.set_fact:
+        upterm_release: "{{ toolbox.upterm.architectures[ansible_facts['architecture']] }}"
+
+    - name: Check installed Upterm version
+      ansible.builtin.command: /usr/local/bin/upterm version
+      register: upterm_installed
+      changed_when: false
+      failed_when: false
+
+    - name: Set installed Upterm version
+      ansible.builtin.set_fact:
+        upterm_current_version: >-
+          {{ upterm_installed.stdout_lines | default([]) | first | default('') |
+          regex_replace('^Upterm version\s+', '') }}
+
+    - name: Install configured Upterm release
+      when: upterm_installed.rc != 0 or upterm_current_version != toolbox.upterm.version
+      block:
+        - name: Create temporary Upterm directory
+          ansible.builtin.tempfile:
+            state: directory
+            prefix: sf-toolbox-upterm-
+          register: upterm_temp_dir
+
+        - name: Download verified Upterm release
+          ansible.builtin.get_url:
+            url: "https://github.com/owenthereal/upterm/releases/download/v{{ toolbox.upterm.version }}/{{ upterm_release.asset }}"
+            dest: "{{ upterm_temp_dir.path }}/{{ upterm_release.asset }}"
+            checksum: "sha256:{{ upterm_release.sha256 }}"
+            mode: "0644"
+
+        - name: Extract Upterm release
+          ansible.builtin.unarchive:
+            src: "{{ upterm_temp_dir.path }}/{{ upterm_release.asset }}"
+            dest: "{{ upterm_temp_dir.path }}"
+            remote_src: true
+
+        - name: Install Upterm binary
+          ansible.builtin.copy:
+            src: "{{ upterm_temp_dir.path }}/upterm"
+            dest: /usr/local/bin/upterm
+            mode: "0755"
+            remote_src: true
+
+        - name: Verify Upterm installation
+          ansible.builtin.command: /usr/local/bin/upterm version
+          register: upterm_verified
+          changed_when: false
+          failed_when: "('Upterm version ' ~ toolbox.upterm.version) not in upterm_verified.stdout"
+
+      always:
+        - name: Clean up Upterm temporary directory
+          ansible.builtin.file:
+            path: "{{ upterm_temp_dir.path }}"
+            state: absent
+          when: upterm_temp_dir is defined and upterm_temp_dir.path is defined
+
+- name: Install Upterm with Homebrew (Debian/Ubuntu)
+  tags: [sf-toolbox, packages, upterm]
+  when: ansible_facts['os_family'] == "Debian"
+  become: true
+  become_user: "{{ system.username | default(current_user) }}"
+  block:
+    - name: Check for legacy Upterm formula
+      ansible.builtin.command:
+        argv:
+          - /home/linuxbrew/.linuxbrew/bin/brew
+          - list
+          - --formula
+          - upterm
+      register: upterm_legacy_formula
+      changed_when: false
+      failed_when: false
+
+    - name: Remove legacy Upterm formula
+      ansible.builtin.command:
+        argv:
+          - /home/linuxbrew/.linuxbrew/bin/brew
+          - uninstall
+          - --formula
+          - upterm
+      when: upterm_legacy_formula.rc == 0
+
+    - name: Install upstream Upterm cask
+      community.general.homebrew_cask:
+        name: upterm
+        state: latest
+        path: /home/linuxbrew/.linuxbrew/bin
+      environment:
+        HOMEBREW_NO_SANDBOX_LINUX: "1"
+
+    - name: Verify Upterm installation
+      ansible.builtin.command: /home/linuxbrew/.linuxbrew/bin/upterm version
+      changed_when: false

--- a/playbooks/roles/sf-toolbox/tasks/upterm.yml
+++ b/playbooks/roles/sf-toolbox/tasks/upterm.yml
@@ -100,6 +100,19 @@
           - upterm
       when: upterm_legacy_formula.rc == 0
 
+    - name: Trust upstream Upterm tap
+      ansible.builtin.shell: |
+        set -uo pipefail
+        if ! /home/linuxbrew/.linuxbrew/bin/brew commands | tr ' ' '\n' | grep -qx trust; then
+          echo "skip: brew trust unavailable"
+          exit 0
+        fi
+        /home/linuxbrew/.linuxbrew/bin/brew trust --tap owenthereal/upterm
+      args:
+        executable: /bin/bash
+      register: upterm_tap_trust
+      changed_when: "'Trusted tap' in upterm_tap_trust.stdout"
+
     - name: Install upstream Upterm cask
       community.general.homebrew_cask:
         name: upterm

--- a/playbooks/roles/sf-toolbox/vars/main.yml
+++ b/playbooks/roles/sf-toolbox/vars/main.yml
@@ -38,6 +38,7 @@ toolbox:
       - npm
     homebrew_taps:
       - anomalyco/tap
+      - owenthereal/upterm
     homebrew:
       - just
       - gum
@@ -84,11 +85,23 @@ toolbox:
     - rg
     - rtk
     - herdr
+    - upterm
     - spark-http-proxy
     - intelephense
     - typescript-language-server
     - pyright-langserver
     - gopls
+
+  # ─── Upterm release (Arch Linux and Omarchy) ────────────────────────────
+  upterm:
+    version: "0.24.0"
+    architectures:
+      x86_64:
+        asset: upterm_linux_amd64.tar.gz
+        sha256: a6324d76c6d962236c22e4a27a2c4ffd17aef11dfa3da33d14dfcff4f4de60b3
+      aarch64:
+        asset: upterm_linux_arm64.tar.gz
+        sha256: 9015aabeeb837ef4c503db56a54a90139b5965a9f16f162b098b1c5acf8d1584
 
   # ─── Prerequisites ──────────────────────────────────────────────────────
   # Must be available as commands before sf-toolbox runs.


### PR DESCRIPTION
### **User description**
> :robot: _This was written by an AI agent on behalf of @paolomainardi._

## Summary

- **Installs** pinned, checksum-verified upstream Upterm release artifacts on Arch Linux and Omarchy.
- **Installs** the upstream `owenthereal/upterm/upterm` Homebrew cask on Debian and Ubuntu.
- **Avoids** AUR packages because upstream authors do not maintain them.
- **Removes** managed `tmate`, `upterm`, and `upterm-bin` Arch packages before installing the upstream binary.
- **Adds** `upterm` detection and a targeted `upterm` Ansible tag.
- **Extends** toolbox CI with installation checks and second-run idempotency checks.

## Validation

- `ansible-playbook playbooks/sf-toolbox.yml -i localhost, -c local --syntax-check`
- `shellcheck bin/install.linux`
- YAML and Upterm release metadata assertions
- Real installation inside `archlinux:latest`
- SHA-256 verification against Upterm `v0.24.0`
- Second Arch container run with `changed=0`
- Installed binary reports `Upterm version 0.24.0`
- `git diff --check`

## Review notes

Arch Linux and Omarchy use official upstream release tarballs. Debian and Ubuntu keep the existing `sf-toolbox` Homebrew ownership model and use the upstream cask, which publishes Linux `amd64` and `arm64` artifacts.

Shared authenticated workflows are provided by sparkfabrik/sparkdock#611.

Closes #266
Refs sparkfabrik/sparkdock#609


___

### **PR Type**
Enhancement, Tests, Documentation


___

### **Description**
- Install Upterm across supported Linux platforms

- Verify releases, versions, and idempotency

- Remove conflicting legacy terminal-sharing packages

- Document Upterm availability and installation behavior


___

### Diagram Walkthrough


```mermaid
flowchart LR
  toolbox["sf-toolbox"]
  arch["Arch Linux and Omarchy"]
  debian["Debian and Ubuntu"]
  release["Verified upstream release"]
  cask["Upstream Homebrew cask"]
  checks["Version and idempotency checks"]
  toolbox -- "detects platform" --> arch
  toolbox -- "detects platform" --> debian
  arch -- "installs pinned binary" --> release
  debian -- "installs cask" --> cask
  release -- "validated by CI" --> checks
  cask -- "validated by CI" --> checks
```



<details> <summary><h3> File Walkthrough</h3></summary>

<table><thead><tr><th></th><th align="left">Relevant files</th></tr></thead><tbody><tr><td><strong>Tests</strong></td><td><details><summary>1 files</summary><table>
<tr>
  <td><strong>test-toolbox.yml</strong><dd><code>Verify Upterm installation and repeat-run idempotency</code>&nbsp; &nbsp; &nbsp; &nbsp; </dd></td>
  <td><a href="https://github.com/sparkfabrik/archlinux-ansible-provisioner/pull/267/files#diff-b1586e2e2e4c94cb3c84cf3e10c2ea4efe281eb6cd41c417ccdc03fb1f0ae40a">+19/-0</a>&nbsp; &nbsp; </td>

</tr>
</table></details></td></tr><tr><td><strong>Documentation</strong></td><td><details><summary>2 files</summary><table>
<tr>
  <td><strong>CHANGELOG.md</strong><dd><code>Document Upterm addition and legacy package removal</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></td>
  <td><a href="https://github.com/sparkfabrik/archlinux-ansible-provisioner/pull/267/files#diff-06572a96a58dc510037d5efa622f9bec8519bc1beab13c9f251e97e657a9d4ed">+3/-0</a>&nbsp; &nbsp; &nbsp; </td>

</tr>

<tr>
  <td><strong>README.md</strong><dd><code>List Upterm among sf-toolbox utilities</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></td>
  <td><a href="https://github.com/sparkfabrik/archlinux-ansible-provisioner/pull/267/files#diff-b335630551682c19a781afebcf4d07bf978fb1f8ac04c6bf87428ed5106870f5">+1/-1</a>&nbsp; &nbsp; &nbsp; </td>

</tr>
</table></details></td></tr><tr><td><strong>Enhancement</strong></td><td><details><summary>3 files</summary><table>
<tr>
  <td><strong>install.linux</strong><dd><code>Recognize managed Upterm binary during conflict checks</code>&nbsp; &nbsp; &nbsp; </dd></td>
  <td><a href="https://github.com/sparkfabrik/archlinux-ansible-provisioner/pull/267/files#diff-877d32c0cf553e367aaf499a3e8982edb759c30fde98862b7039c47a2f128e58">+1/-0</a>&nbsp; &nbsp; &nbsp; </td>

</tr>

<tr>
  <td><strong>main.yml</strong><dd><code>Include Upterm installation in toolbox workflow</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></td>
  <td><a href="https://github.com/sparkfabrik/archlinux-ansible-provisioner/pull/267/files#diff-c8105664846b49ed10cd80366133e828343729d603acd55cdfe248515ad596b3">+3/-0</a>&nbsp; &nbsp; &nbsp; </td>

</tr>

<tr>
  <td><strong>upterm.yml</strong><dd><code>Install verified Upterm releases across Linux platforms</code>&nbsp; &nbsp; </dd></td>
  <td><a href="https://github.com/sparkfabrik/archlinux-ansible-provisioner/pull/267/files#diff-e94f7ed58781708ddd89f7e4a3ed5fc915e5d6fa1e037636de095a51b086fa5d">+113/-0</a>&nbsp; </td>

</tr>
</table></details></td></tr><tr><td><strong>Dependencies</strong></td><td><details><summary>1 files</summary><table>
<tr>
  <td><strong>development.yml</strong><dd><code>Remove legacy tmate package from Arch provisioning</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></td>
  <td><a href="https://github.com/sparkfabrik/archlinux-ansible-provisioner/pull/267/files#diff-522557779cd8352aeae47439bfc5937da6829c14365c61c91e2a2e0b01b318db">+0/-1</a>&nbsp; &nbsp; &nbsp; </td>

</tr>
</table></details></td></tr><tr><td><strong>Configuration changes</strong></td><td><details><summary>2 files</summary><table>
<tr>
  <td><strong>homebrew.yml</strong><dd><code>Enable Homebrew bootstrap through Upterm tag</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></td>
  <td><a href="https://github.com/sparkfabrik/archlinux-ansible-provisioner/pull/267/files#diff-6a424139e4ee18cdd676b3424d54d5699d2f32a18d200ff411a64a0029c226dc">+1/-1</a>&nbsp; &nbsp; &nbsp; </td>

</tr>

<tr>
  <td><strong>main.yml</strong><dd><code>Configure Upterm releases, checksums, and Homebrew tap</code>&nbsp; &nbsp; &nbsp; </dd></td>
  <td><a href="https://github.com/sparkfabrik/archlinux-ansible-provisioner/pull/267/files#diff-16964a1dffd1e12a18adb38c0e1d0d795275ba9e377f03be930b1b60e269d494">+13/-0</a>&nbsp; &nbsp; </td>

</tr>
</table></details></td></tr></tr></tbody></table>

</details>

___



---

> Assisted-by: pr-agent/gpt-5.6-sol